### PR TITLE
Fixes for MacOS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -40,4 +40,4 @@ time_extra.o: time_extra.c time_extra.h
 
 .PHONY: clean
 clean:
-	rm *.o check time_test grid_gen
+	rm -f *.o check time_test grid_gen

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,18 +1,30 @@
-CC     = gcc
+UNAME_S := $(shell uname -s)
+
+ifeq ($(UNAME_S),Linux)
+    CC     = gcc
+    CC_OMP = -fopenmp
+    CC_PTH = -pthread
+endif
+ifeq ($(UNAME_S),Darwin)    # Darwin is for MacOS
+    CC = /opt/homebrew/opt/llvm/bin/clang
+    CC_OMP = -fopenmp=libomp
+    CC_PTH = -pthread
+    LDFLAGS = -L/opt/homebrew/opt/llvm/lib -Wl,-rpath,/opt/homebrew/opt/llvm/lib
+    CPPFLAGS = -I/opt/homebrew/opt/llvm/include
+endif
+
 CFLAGS = -Wall -pedantic -O2 -std=c11
-CC_OMP = -fopenmp
-CC_PTH = -pthread
 
 all: check time_test grid_gen
 
 check: check.o lga_base.o lga_seq.o lga_omp.o lga_pth.o
-	$(CC) $(CFLAGS) $(CC_OMP) $(CC_PTH) -o $@ $^
+	$(CC) $(CFLAGS) $(CC_OMP) $(CC_PTH) -o $@ $^ $(LDFLAGS)
 
 check.o: check.c lga_base.o
 	$(CC) $(CFLAGS) -c $<
 
 time_test: time_test.o lga_base.o lga_seq.o lga_omp.o lga_pth.o time_extra.o
-	$(CC) $(CFLAGS) $(CC_OMP) $(CC_PTH) -o $@ $^
+	$(CC) $(CFLAGS) $(CC_OMP) $(CC_PTH) -o $@ $^ $(LDFLAGS)
 
 time_test.o: time_test.c lga_base.o
 	$(CC) $(CFLAGS) -c $<

--- a/src/Makefile
+++ b/src/Makefile
@@ -35,7 +35,7 @@ lga_seq.o: lga_seq.c lga_seq.h lga_base.o
 lga_omp.o: lga_omp.c lga_omp.h lga_base.o
 	$(CC) $(CFLAGS) $(CC_OMP) -c $<
 
-lga_pth.o: lga_pth.c lga_pth.h lga_base.o
+lga_pth.o: lga_pth.c pthread_barrier.h lga_pth.h lga_base.o
 	$(CC) $(CFLAGS) $(CC_PTH) -c $<
 
 grid_gen: grid_gen.o lga_base.o

--- a/src/check.c
+++ b/src/check.c
@@ -65,7 +65,7 @@ bool are_grids_equal(byte* grid_a, byte* grid_b, int grid_size) {
     for (int idx = 0; idx < grid_size*grid_size; idx++)
         if (grid_a[idx] != grid_b[idx])
             return false;
-    
+
     return true;
 }
 
@@ -94,7 +94,7 @@ int main(int argc, char *argv[]) {
         printf("Resultado OpenMP igual ao sequencial\n");
     else
         printf("Resultado OpenMP DIFERENTE do sequencial\n");
-    
+
     printf("Executando versao Pthreads...\n");
     initialize_grids(grid_1, grid_2, grid_size);
     simulate_pth(grid_1, grid_2, grid_size, num_threads);

--- a/src/grid_gen.c
+++ b/src/grid_gen.c
@@ -6,7 +6,7 @@
 
 #define DENSITY 0.05
 
-// Procedimento auxiliar para inicializar o gerador de 
+// Procedimento auxiliar para inicializar o gerador de
 // numeros pseudo-aleatorios (PRNG).
 // Utiliza-se o Unix time em microssegundos (us) como seed.
 void initialize_prng(void)
@@ -22,7 +22,7 @@ void initialize_prng(void)
 
 void generate_grid(byte *grid, int grid_size) {
     int dir;
-    
+
     for (int i = 0; i < grid_size; i++) {
         for (int j = 0; j < grid_size; j++) {
             if (i == 0 || j == 0 || i == grid_size - 1 || j == grid_size - 1) {

--- a/src/lga_base.c
+++ b/src/lga_base.c
@@ -201,7 +201,7 @@ void print_grid(byte *grid, int grid_size) {
     }
 }
 
-// Imprime o estado atual da simulacao para gerar uma 
+// Imprime o estado atual da simulacao para gerar uma
 // animacao ASCII da simulacao
 void print_grid_animation(byte *grid, int grid_size) {
     for (int i = 0; i < grid_size; i++) {

--- a/src/lga_omp.c
+++ b/src/lga_omp.c
@@ -16,7 +16,7 @@ static byte get_next_cell(int i, int j, byte *grid_in, int grid_size) {
         if (inbounds(n_i, n_j, grid_size)) {
             if (grid_in[ind2d(n_i,n_j)] == WALL) {
                 next_cell |= from_wall_collision(i, j, grid_in, grid_size, dir);
-            } 
+            }
             else if (grid_in[ind2d(n_i, n_j)] & rev_dir_mask) {
                 next_cell |= rev_dir_mask;
             }
@@ -29,9 +29,9 @@ static byte get_next_cell(int i, int j, byte *grid_in, int grid_size) {
 static void update(byte *grid_in, byte *grid_out, int grid_size) {
     for (int i = 0; i < grid_size; i++) {
         for (int j = 0; j < grid_size; j++) {
-            if (grid_in[ind2d(i,j)] == WALL) 
+            if (grid_in[ind2d(i,j)] == WALL)
                 grid_out[ind2d(i,j)] = WALL;
-            else 
+            else
                 grid_out[ind2d(i,j)] = get_next_cell(i, j, grid_in, grid_size);
         }
     }

--- a/src/lga_pth.c
+++ b/src/lga_pth.c
@@ -16,7 +16,7 @@ static byte get_next_cell(int i, int j, byte *grid_in, int grid_size) {
         if (inbounds(n_i, n_j, grid_size)) {
             if (grid_in[ind2d(n_i,n_j)] == WALL) {
                 next_cell |= from_wall_collision(i, j, grid_in, grid_size, dir);
-            } 
+            }
             else if (grid_in[ind2d(n_i, n_j)] & rev_dir_mask) {
                 next_cell |= rev_dir_mask;
             }
@@ -29,9 +29,9 @@ static byte get_next_cell(int i, int j, byte *grid_in, int grid_size) {
 static void update(byte *grid_in, byte *grid_out, int grid_size) {
     for (int i = 0; i < grid_size; i++) {
         for (int j = 0; j < grid_size; j++) {
-            if (grid_in[ind2d(i,j)] == WALL) 
+            if (grid_in[ind2d(i,j)] == WALL)
                 grid_out[ind2d(i,j)] = WALL;
-            else 
+            else
                 grid_out[ind2d(i,j)] = get_next_cell(i, j, grid_in, grid_size);
         }
     }

--- a/src/lga_seq.c
+++ b/src/lga_seq.c
@@ -27,7 +27,7 @@ static byte get_next_cell(int i, int j, byte *grid_in, int grid_size) {
             // em (i, j) uma particula que colidiu com a parede
             if (grid_in[ind2d(n_i,n_j)] == WALL) {
                 next_cell |= from_wall_collision(i, j, grid_in, grid_size, dir);
-            } 
+            }
             // Caso haja uma particula vindo do vizinho para a celula,
             // atualiza a celula colocando nela essa particula
             else if (grid_in[ind2d(n_i, n_j)] & rev_dir_mask) {
@@ -36,7 +36,7 @@ static byte get_next_cell(int i, int j, byte *grid_in, int grid_size) {
         }
     }
 
-    // Etapa de colisao: verifica se apos a propagacao, 
+    // Etapa de colisao: verifica se apos a propagacao,
     // houve colisao entre particulas em (i, j)
     return check_particles_collision(next_cell);
 }
@@ -46,9 +46,9 @@ static byte get_next_cell(int i, int j, byte *grid_in, int grid_size) {
 static void update(byte *grid_in, byte *grid_out, int grid_size) {
     for (int i = 0; i < grid_size; i++) {
         for (int j = 0; j < grid_size; j++) {
-            if (grid_in[ind2d(i,j)] == WALL) 
+            if (grid_in[ind2d(i,j)] == WALL)
                 grid_out[ind2d(i,j)] = WALL;
-            else 
+            else
                 grid_out[ind2d(i,j)] = get_next_cell(i, j, grid_in, grid_size);
         }
     }

--- a/src/pthread_barrier.h
+++ b/src/pthread_barrier.h
@@ -1,0 +1,68 @@
+#ifdef __APPLE__
+
+#ifndef PTHREAD_BARRIER_H_
+#define PTHREAD_BARRIER_H_
+
+#include <pthread.h>
+#include <errno.h>
+
+typedef int pthread_barrierattr_t;
+typedef struct
+{
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    int count;
+    int tripCount;
+} pthread_barrier_t;
+
+
+int pthread_barrier_init(pthread_barrier_t *barrier, const pthread_barrierattr_t *attr, unsigned int count)
+{
+    if(count == 0)
+    {
+        errno = EINVAL;
+        return -1;
+    }
+    if(pthread_mutex_init(&barrier->mutex, 0) < 0)
+    {
+        return -1;
+    }
+    if(pthread_cond_init(&barrier->cond, 0) < 0)
+    {
+        pthread_mutex_destroy(&barrier->mutex);
+        return -1;
+    }
+    barrier->tripCount = count;
+    barrier->count = 0;
+
+    return 0;
+}
+
+int pthread_barrier_destroy(pthread_barrier_t *barrier)
+{
+    pthread_cond_destroy(&barrier->cond);
+    pthread_mutex_destroy(&barrier->mutex);
+    return 0;
+}
+
+int pthread_barrier_wait(pthread_barrier_t *barrier)
+{
+    pthread_mutex_lock(&barrier->mutex);
+    ++(barrier->count);
+    if(barrier->count >= barrier->tripCount)
+    {
+        barrier->count = 0;
+        pthread_cond_broadcast(&barrier->cond);
+        pthread_mutex_unlock(&barrier->mutex);
+        return 1;
+    }
+    else
+    {
+        pthread_cond_wait(&barrier->cond, &(barrier->mutex));
+        pthread_mutex_unlock(&barrier->mutex);
+        return 0;
+    }
+}
+
+#endif // PTHREAD_BARRIER_H_
+#endif // __APPLE__

--- a/src/time_test.c
+++ b/src/time_test.c
@@ -69,7 +69,7 @@ void parse_arguments(int argc, char *argv[], int *grid_size_ptr, int *impl_ptr, 
         exit(EXIT_FAILURE);
     }
 
-    
+
     if (*grid_size_ptr < MIN_GRID_SIZE || *grid_size_ptr > MAX_GRID_SIZE) {
         printf("Invalid grid_size %d (min=%d, max=%d)\n",
             *grid_size_ptr, MIN_GRID_SIZE, MAX_GRID_SIZE);
@@ -94,7 +94,7 @@ int main(int argc, char *argv[]) {
     byte *grid_2;
     int grid_size, impl, num_threads;
     struct timeval t1, t2, t3;
-    
+
     parse_arguments(argc, argv, &grid_size, &impl, &num_threads);
 
     grid_1 = allocate_grid(grid_size);
@@ -117,7 +117,7 @@ int main(int argc, char *argv[]) {
     gettimeofday(&t2, NULL);
 
     timeval_subtract(&t3, &t2, &t1);
-    
+
     printf("%lu.%06lu\n", t3.tv_sec, t3.tv_usec);
 
     free(grid_1);


### PR DESCRIPTION
This PR allows for making the exercise on MacOS (tested on M1 running Ventura 13.4.1).

### For students

To compile on MacOS one simply needs to `brew install libomp llvm`. Then, to use pthread barriers it suffices to `#include "pthread_barrier.h"`.

### Para os estudantes

Para compilar no MacOS, primeiro instale as dependências rodando `brew install libomp llvm`. Então, se desejar usar barreiras de pthreads, basta usar a diretiva `#include "pthread_barrier.h"` no seu código.